### PR TITLE
Fixes error in Vote constructor

### DIFF
--- a/konsent/models.py
+++ b/konsent/models.py
@@ -133,7 +133,7 @@ class Vote(db.Model):
         else:
             self.author_id = author
         if isinstance(target, Post):
-            self.post = Post
+            self.post = target
         elif isinstance(target, Comment):
             self.comment = target
         elif target_type == 'post':


### PR DESCRIPTION
This fixes the `AttributeError: type object 'Post' has no attribute '_sa_instance_state'.` mentioned in #25 